### PR TITLE
ENCD-5437 Support arrow highlighting icons

### DIFF
--- a/lib/add-decoration.js
+++ b/lib/add-decoration.js
@@ -1,0 +1,62 @@
+
+/**
+ * Draws a box currently inside the top edge of a node with an optional icon drawn inside, though
+ * future development would include other positions as needed.
+ */
+
+module.exports = addDecoration;
+
+
+/** Override the default decoration width and height with node.decoration.width and .height */
+var DEFAULT_DECORATION_WIDTH = 26;
+var DEFAULT_DECORATION_HEIGHT = 14;
+var DEFAULT_DECORATION_POSITION = 'top';
+
+
+// Defined icon variants. Add other variants to this object as needed.
+var iconDefs = {
+  // Arrow head pointing right.
+  'arrow-right': function(decorationGroup, decorationWidth, decorationHeight) {
+      var bbox = decorationGroup.node().getBBox();
+      decorationGroup
+        .attr("d", d3.svg.symbol().type('triangle-up').size(34))
+        .attr("transform", "translate(0," + (decorationHeight / 2) + ") rotate(90)");
+      return decorationGroup;
+  },
+};
+
+
+/**
+ * Add a decoration to the node in the requested position.
+ */
+function addDecoration(root, node) {
+  var decorationWidth = node.decoration.width || DEFAULT_DECORATION_WIDTH;
+  var decorationHeight = node.decoration.height || DEFAULT_DECORATION_HEIGHT;
+  var decorationPosition = node.decoration.position || DEFAULT_DECORATION_POSITION;
+  var decorationGroup = root.append("g").attr("class", "decoration" + (node.decoration.class ? " " + node.decoration.class : ""));
+  var horzStart = decorationWidth / 2;
+
+  // Add more decoration positions as needed.
+  if (decorationPosition === "top") {
+    // Draw the rectangle for the decoration.
+    decorationGroup.append("rect")
+      .attr("x", -horzStart)
+      .attr("y", 1)
+      .attr("width", decorationWidth)
+      .attr("height", decorationHeight);
+
+    // Draw the three-sided border around the decoration.
+    decorationGroup.append("polyline")
+      .attr("class", "decoration__border")
+      .attr("points", -horzStart + ",0 " + -horzStart + "," + (decorationHeight + 1) + " " + horzStart + "," + (decorationHeight + 1) + " " + horzStart + ",0");
+  }
+
+  // Draw any requested icon in the middle of the decoration.
+  if (node.decoration.icon) {
+    var decorationPath = decorationGroup.append("path")
+      .attr("class", "decoration__icon")
+    iconDefs[node.decoration.icon](decorationPath, decorationWidth, decorationHeight);
+  }
+
+  return decorationGroup;
+}

--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -92,7 +92,11 @@ function getCoords(elem) {
 function enter(svgPaths, g) {
   var svgPathsEnter = svgPaths.enter()
     .append("g")
-      .attr("class", "edgePath")
+      .attr("class", function(e) {
+        // Apply any CSS classes specific to each edge in the graph.
+        var edge = g.edge(e);
+        return "edgePath" + (edge.class ? " " + edge.class : "");
+      })
       .style("opacity", 0);
   svgPathsEnter.append("path")
     .attr("class", "path")

--- a/lib/create-nodes.js
+++ b/lib/create-nodes.js
@@ -3,11 +3,20 @@
 var _ = require("./lodash"),
     addLabel = require("./label/add-label"),
     addSubnodes = require("./add-subnodes"),
+    addDecoration = require("./add-decoration"),
     util = require("./util"),
     d3 = require("./d3");
 
 module.exports = createNodes;
 
+/**
+ * Create the nodes that have been set in a dagre-d3 graph within a d3 selection. Each node
+ * definition in `g` includes a shape for that node, and the `shapes` parameter includes
+ * renderers for every defined kind of shape.
+ * @param {object} selection d3 selection to create the nodes within
+ * @param {object} g dagre-d3 graph containing the node definitions
+ * @param {object} shapes pre-defined node shapes
+ */
 function createNodes(selection, g, shapes) {
   var simpleNodes = g.nodes().filter(function(v) { return !util.isSubgraph(g, v); });
   var svgNodes = selection.selectAll("g.node")
@@ -21,6 +30,7 @@ function createNodes(selection, g, shapes) {
       .style("opacity", 0);
   svgNodes.each(function(v) {
     var subnodeGroup, subnodeDom;
+    var decorationGroup;
     var subnodeBBox = {width: 0, height: 0};
     var node = g.node(v),
         thisGroup = d3.select(this),
@@ -45,6 +55,15 @@ function createNodes(selection, g, shapes) {
       subnodeBBox.width = subnodeBBox.height = 0;
     }
 
+    // Render node decorations if specified.
+    if (node.decoration) {
+      decorationGroup = addDecoration(thisGroup, node);
+      
+      // Add margins to the node to give decorations some space.
+      var decorationBBox = decorationGroup.node().getBBox();
+      bbox.height += decorationBBox.height;
+    }
+
     if (node.id) { thisGroup.attr("id", node.id); }
     if (node.labelId) { labelGroup.attr("id", node.labelId); }
     util.applyClass(thisGroup, node["class"],
@@ -62,6 +81,15 @@ function createNodes(selection, g, shapes) {
       subnodeGroup.attr("transform", "translate(" +
         -((subnodeBBox.width / 2) - 10) + "," +
         ((node.paddingTop - node.paddingBottom + subnodeBBox.height) / 2) + ")");
+    }
+
+    // Translate the decoration to pin it against one side of the parent node group.
+    if (decorationGroup) {
+      // Stacks and contributing files get drawn differently, so they need a vertical adjustment,
+      // combined if requested.
+      let clusterAdjustment = node.class.indexOf("contributing") !== -1 ? -1 : 0;
+      clusterAdjustment += node.shape === "stack" ? -4 : 0;
+      decorationGroup.attr("transform", "translate(0," + ((-bbox.height / 2) + clusterAdjustment) + ")");
     }
 
     var shapeSvg = shape(d3.select(this), bbox, node);

--- a/lib/shapes.js
+++ b/lib/shapes.js
@@ -46,7 +46,7 @@ function rect(parent, bbox, node) {
 
 // Draw a stack of three rects, to represent an indefinite number of coalesced rects.
 function stack(parent, bbox, node) {
-  var shapeSvg = parent.insert('g', ':first-child');
+  var shapeSvg = parent.insert('g', ':first-child').attr("class", "stack");
   shapeSvg.append('rect')
         .attr('rx', node.rx)
         .attr('ry', node.ry)


### PR DESCRIPTION
These changes to dagre-d3 let encoded specify a “decoration” to draw on the upper edge of every node in a file graph, and a CSS class on the “edges” which render the arrows in the graph.

I tried to make it flexible so encoded can draw different things in the future, but for now it just draws a box with a right-pointing arrowhead on the upper edge of each node in the graph.

Here’s an example file graph with lots of nodes and the decorations on each:
https://encd-5437-graph-arrows-fytanaka.demo.encodedcc.org/experiments/ENCSR483RKN/

A PR for the corresponding encoded branch will come later.